### PR TITLE
Forward stop(Immediate)Propagation functions in normalized event object

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,6 +57,10 @@ function _addWheelListener( elem, eventName, callback, useCapture ) {
       stopPropagation: function() {
         if(originalEvent.stopPropagation)
           originalEvent.stopPropagation();
+      },
+      stopImmediatePropagation: function() {
+        if(originalEvent.stopImmediatePropagation)
+          originalEvent.stopImmediatePropagation();
       }
     };
 

--- a/index.js
+++ b/index.js
@@ -53,6 +53,10 @@ function _addWheelListener( elem, eventName, callback, useCapture ) {
         originalEvent.preventDefault ?
             originalEvent.preventDefault() :
             originalEvent.returnValue = false;
+      },
+      stopPropagation: function() {
+        if(originalEvent.stopPropagation)
+          originalEvent.stopPropagation();
       }
     };
 


### PR DESCRIPTION
This is missing in the MDN "polyfill" code but results in problems with the replacement event object in browsers that have not implemented the wheel event yet.
