### PR TITLE
removeWheelListener method added

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,12 @@ for more details.
 # Usage
 
 ``` js
-var addWheelListener = require('wheel');
+var addWheelListener = require('wheel/addWheelListener');
+var removeWheelListener = require('wheel/removeWheelListener');
 addWheelListener(domElement, function (e) {
-  // mouse wheel event
+	// mouse wheel event
 });
+removeWheelListener(domElement, function);
 ```
 
 # install

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ for more details.
 # Usage
 
 ``` js
-var addWheelListener = require('wheel/addWheelListener');
-var removeWheelListener = require('wheel/removeWheelListener');
+var addWheelListener = require('wheel').addWheelListener;
+var removeWheelListener = require('wheel').removeWheelListener;
 addWheelListener(domElement, function (e) {
 	// mouse wheel event
 });

--- a/index.js
+++ b/index.js
@@ -5,8 +5,8 @@
  * for more details
  *
  * Usage:
- *  var addWheelListener = require('wheel/addWheelListener');
- *  var removeWheelListener = require('wheel/removeWheelListener');
+ *  var addWheelListener = require('wheel').addWheelListener;
+ *  var removeWheelListener = require('wheel').removeWheelListener;
  *  addWheelListener(domElement, function (e) {
  *    // mouse wheel event
  *  });

--- a/index.js
+++ b/index.js
@@ -5,20 +5,27 @@
  * for more details
  *
  * Usage:
- *  var addWheelListener = require('wheel');
+ *  var addWheelListener = require('wheel/addWheelListener');
+ *  var removeWheelListener = require('wheel/removeWheelListener');
  *  addWheelListener(domElement, function (e) {
  *    // mouse wheel event
  *  });
+ *  removeWheelListener(domElement, function);
  */
-module.exports = addWheelListener;
+module.exports = {
+    addWheelListener: addWheelListener,
+    removeWheelListener: removeWheelListener
+}
 
-var prefix = "", _addEventListener, onwheel, support;
+var prefix = "", _addEventListener, _removeEventListener, onwheel, support;
 
 // detect event model
 if ( window.addEventListener ) {
     _addEventListener = "addEventListener";
+    _removeEventListener = "removeEventListener";
 } else {
     _addEventListener = "attachEvent";
+    _removeEventListener = "detachEvent";
     prefix = "on";
 }
 
@@ -33,6 +40,15 @@ function addWheelListener( elem, callback, useCapture ) {
     // handle MozMousePixelScroll in older Firefox
     if( support == "DOMMouseScroll" ) {
         _addWheelListener( elem, "MozMousePixelScroll", callback, useCapture );
+    }
+};
+
+function removeWheelListener( elem, callback, useCapture ) {
+    _removeWheelListener( elem, support, callback, useCapture );
+
+    // handle MozMousePixelScroll in older Firefox
+    if( support == "DOMMouseScroll" ) {
+        _removeWheelListener( elem, "MozMousePixelScroll", callback, useCapture );
     }
 };
 
@@ -77,4 +93,8 @@ function _addWheelListener( elem, eventName, callback, useCapture ) {
     return callback( event );
 
   }, useCapture || false );
+}
+
+function _removeWheelListener( elem, eventName, callback, useCapture ) {
+  elem[ _removeEventListener ]( prefix + eventName, callback, useCapture || false );
 }


### PR DESCRIPTION
Hi @anvaka ,

I added the removeWheelListener method, README updated also.
The difference now is that the `exports` targets to an object that holds both `addWheelListener` and `removeWheelListener`. Before it was targeting directly just to `addWheelListener`.
I hope it's working for you.

Best,
Panos
